### PR TITLE
SEO: canonical URLs, sitemap and heading structure

### DIFF
--- a/src/lib/components/pages/VsrgComposer/VsrgComposerMenu.svelte
+++ b/src/lib/components/pages/VsrgComposer/VsrgComposerMenu.svelte
@@ -300,9 +300,9 @@
         <SettingsPane settings={data.settings} onUpdate={functions.handleSettingChange} />
         <div class="column vsrg-select-song-wrapper">
           <Row align="center">
-            <h1 class="settings-group-title row-centered">
+            <h2 class="settings-group-title row-centered">
               {t('vsrg_composer:background_song')}
-            </h1>
+            </h2>
             <HelpTooltip
               buttonStyle="width:1.2rem;height:1.2rem;margin-left:0.5rem"
               position="middle"

--- a/src/lib/components/settings/SettingsPane.svelte
+++ b/src/lib/components/settings/SettingsPane.svelte
@@ -49,9 +49,9 @@
 
 {#each groups as group (group.category)}
   <div class="column">
-    <h1 class="settings-group-title">
+    <h2 class="settings-group-title">
       {t(`settings:category.${group.category}`)}
-    </h1>
+    </h2>
     {#each Object.entries(group.settings) as [key, setting] (key)}
       <fieldset class="settings-row-fieldset" disabled={songLocked && setting.songSetting}>
         <SettingsRow

--- a/src/lib/components/shell/HomeContent.svelte
+++ b/src/lib/components/shell/HomeContent.svelte
@@ -323,9 +323,9 @@
 <div class="home-padded column">
   {#if alwaysShowTitle || breakpoint || !hasVisited}
     <div class="home-top">
-      <div class="home-title">
+      <h1 class="home-title">
         {game.meta.title}
-      </div>
+      </h1>
       <div class="home-top-text">
         {t('home:app_description', { APP_NAME })}
       </div>
@@ -407,10 +407,10 @@
         style="background-image:url('{base}/manifestData/composer.webp')"
       ></div>
       <div class="home-content-main" style="background-color:{cardBackground}">
-        <div class="home-content-title">
+        <h2 class="home-content-title">
           {@render faCompactDiscIcon()}
           {t('home:composer_name')}
-        </div>
+        </h2>
         <div class="home-content-text">
           {t('home:composer_description')}
         </div>
@@ -435,10 +435,10 @@
         style="background-image:url('{base}/manifestData/player.webp')"
       ></div>
       <div class="home-content-main" style="background-color:{cardBackground}">
-        <div class="home-content-title">
+        <h2 class="home-content-title">
           {@render bsMusicPlayerFillIcon()}
           {t('home:player_name')}
-        </div>
+        </h2>
         <div class="home-content-text">
           {t('home:player_description')}
         </div>
@@ -678,6 +678,9 @@
   }
 
   .home-content-title {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -819,6 +822,9 @@
 
   .home-title {
     font-size: 2rem;
+    margin: 0;
+    font-weight: bold;
+    line-height: 1.2;
   }
 
   .home-top-text {

--- a/src/lib/components/shell/HomePage.svelte
+++ b/src/lib/components/shell/HomePage.svelte
@@ -8,6 +8,7 @@
   import { game } from '$game';
   import { t } from '$i18n/binding.svelte';
   import PageMetadata from './PageMetadata.svelte';
+  import { jsonLdScriptTag, softwareApplicationLd } from '$lib/seo';
   import SimpleMenu from './SimpleMenu.svelte';
   import HomeContent from './HomeContent.svelte';
 
@@ -52,7 +53,16 @@
   const backgroundColor = $derived(ThemeProvider.get('background').fade(0.1).toString());
 </script>
 
-<PageMetadata text={game.meta.title} description={t('home:app_description', { APP_NAME })} />
+<PageMetadata text={game.meta.title} description={t('home:app_description', { APP_NAME })}>
+  <!-- The page's schema.org description. {@html} is the only way to emit a <script> from a
+       component: <svelte:element this="script"> renders nothing in Svelte, and a literal
+       script tag here is taken as the component's own instance script. Safe because the
+       payload is machine generated from game.json and serializeJsonLd escapes < > and &, so
+       nothing interpolated can close the tag - jsonLdScriptTag ($lib/seo) assembles it.
+       test/i18n.test.ts allowlists this one call site and asserts it interpolates no t(). -->
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html jsonLdScriptTag(softwareApplicationLd())}
+</PageMetadata>
 
 <!-- THE SAME RAIL EVERY OTHER PAGE HAS, so the shell never disappears under the user: the home
      button at its end (a no-op here, and deliberately still there - it is the anchor the rail is

--- a/src/lib/components/shell/PageHeading.svelte
+++ b/src/lib/components/shell/PageHeading.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  /**
+   * The document's <h1>, for the app surfaces that have no room for a visible one — the
+   * player, the composer and the rest are a full-window canvas with a rail, not a page
+   * with a masthead. Every page still needs to say what it is: this is what a screen
+   * reader announces first and what a crawler reads as the page's subject, and without
+   * it those pages ship with no heading at all.
+   *
+   * Not folded into PageMetadata: that component renders only into <svelte:head>, and
+   * some routes deliberately mount several of it (routes/theme/+page.svelte).
+   */
+  let { text }: { text: string } = $props();
+</script>
+
+<h1>{text}</h1>
+
+<style>
+  /* Off-screen rather than display:none — a hidden element is skipped by screen readers
+     too, which would defeat half the point. */
+  h1 {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/lib/components/shell/PageMetadata.svelte
+++ b/src/lib/components/shell/PageMetadata.svelte
@@ -18,6 +18,7 @@
 
 <svelte:head>
   <title>{text}</title>
+  <meta property="og:title" content={text} />
   {#if description}
     <meta name="description" content={description} />
     <meta property="og:description" content={description} />

--- a/src/lib/components/shell/RootMetadata.svelte
+++ b/src/lib/components/shell/RootMetadata.svelte
@@ -1,6 +1,19 @@
 <script lang="ts">
   import { base } from '$app/paths';
+  import { page } from '$app/state';
   import { IS_BETA } from '$lib/env';
+  import { CANONICAL_ORIGIN } from '$lib/seo';
+  import { appPathname } from '$lib/utils/appPathname';
+
+  // One canonical per page, which is why it lives here and not in PageMetadata: several
+  // routes mount more than one of those on purpose (routes/theme/+page.svelte), and Svelte
+  // dedupes <title> but not <link>.
+  //
+  // The same pages are served from the per-game domain, the /skyMusic and /genshinMusic
+  // subpath builds and the beta; all of them name the game's own canonical origin so the
+  // copies consolidate onto it instead of competing. appPathname drops the base, which is
+  // exactly the part that differs between those builds.
+  let canonicalUrl = $derived(`${CANONICAL_ORIGIN}${appPathname(page.url.pathname)}`);
 
   // Carries every root-level head element old's metadata cascade produced
   // EXCEPT <title>/<meta name="description"> and the favicon - see the two
@@ -28,6 +41,8 @@
 </script>
 
 <svelte:head>
+  <link rel="canonical" href={canonicalUrl} />
+  <meta property="og:url" content={canonicalUrl} />
   <link rel="manifest" href="{base}/manifest.json" />
   <link rel="apple-touch-icon" href="{base}/logo192.png" />
   {#if IS_BETA}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -15,3 +15,11 @@
 // `PUBLIC_IS_BETA=true npm run build:genshin` + grepping the emitted output for the
 // inlined `true`.
 export const IS_BETA = import.meta.env.PUBLIC_IS_BETA === 'true';
+
+// PUBLIC_CANONICAL_ORIGIN overrides each game's own `meta.canonicalOrigin` (game.json).
+// Unset in every build today, so each game canonicalises to its own production origin;
+// the single-domain deploy sets it once and every page follows. Read through
+// import.meta.env for the same reason IS_BETA is: $env/static/public hard-errors on an
+// import that is not present in the environment, which an optional var never is.
+export const CANONICAL_ORIGIN_OVERRIDE = import.meta.env.PUBLIC_CANONICAL_ORIGIN as
+  string | undefined;

--- a/src/lib/games/genshin/game.json
+++ b/src/lib/games/genshin/game.json
@@ -16,6 +16,7 @@
   "meta": {
     "title": "Genshin Music Nightly",
     "description": "Genshin music, a website to play, practice and compose songs",
+    "canonicalOrigin": "https://genshin-music.specy.app",
     "themeColor": "#63aea7",
     "analytics": {
       "tagId": "G-T3TJDT2NFS",

--- a/src/lib/games/genshin/static/robots.txt
+++ b/src/lib/games/genshin/static/robots.txt
@@ -1,3 +1,7 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+# Absolute by spec. Always the game's canonical origin, never the deployed one: the
+# subpath and beta builds serve these same pages and point crawlers back here too.
+Sitemap: https://genshin-music.specy.app/sitemap.xml

--- a/src/lib/games/schema.ts
+++ b/src/lib/games/schema.ts
@@ -168,6 +168,14 @@ export type GameJson = {
   meta: {
     title: string;
     description: string;
+    /**
+     * The origin this game's pages want to be ranked as. Every build of a game — the
+     * per-game Cloudflare deploys, the subpath `-no-root` builds, the beta — serves the
+     * same content, so each one points crawlers back at this single origin instead of
+     * competing with the others. PUBLIC_CANONICAL_ORIGIN overrides it, which is the one
+     * change the eventual single-domain deploy needs.
+     */
+    canonicalOrigin: string;
     themeColor: string;
     analytics: { tagId: string; configId: string };
     updateChannelKey: StorageId;

--- a/src/lib/games/sky/game.json
+++ b/src/lib/games/sky/game.json
@@ -16,6 +16,7 @@
   "meta": {
     "title": "Sky Music Nightly",
     "description": "Sky music nightly, a website to play, practice and compose songs",
+    "canonicalOrigin": "https://sky-music.specy.app",
     "themeColor": "#63aea7",
     "analytics": {
       "tagId": "G-YEHPSLXGYT",

--- a/src/lib/games/sky/static/robots.txt
+++ b/src/lib/games/sky/static/robots.txt
@@ -1,3 +1,7 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+# Absolute by spec. Always the game's canonical origin, never the deployed one: the
+# subpath and beta builds serve these same pages and point crawlers back here too.
+Sitemap: https://sky-music.specy.app/sitemap.xml

--- a/src/lib/games/types.ts
+++ b/src/lib/games/types.ts
@@ -378,6 +378,7 @@ export interface GameDefinition {
   meta: {
     title: string; // '{name} Music Nightly'
     description: string; // per-game <meta> + manifest description
+    canonicalOrigin: string; // rel=canonical origin; PUBLIC_CANONICAL_ORIGIN overrides
     themeColor: string; // viewport theme-color (#63aea7 today, both games)
     analytics: { tagId: string; configId: string }; // per-game Google Analytics ids
     updateChannelKey: StorageId; // key into updates.json (= storageId)

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,57 @@
+import { game } from '$game';
+import { CANONICAL_ORIGIN_OVERRIDE } from '$lib/env';
+
+/** The origin this build's pages declare as their own — see game.json's `canonicalOrigin`. */
+export const CANONICAL_ORIGIN = CANONICAL_ORIGIN_OVERRIDE || game.meta.canonicalOrigin;
+
+/** `</script>` inside a JSON string would close the surrounding tag; escaping the three
+ *  characters that can do that keeps it valid JSON but inert as markup. */
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
+/**
+ * The complete <script type="application/ld+json"> element for a schema.org payload.
+ *
+ * Assembled here rather than in the component because a literal closing script tag inside
+ * a Svelte template ends the component's own script block as far as the parser is
+ * concerned. serializeJsonLd has already escaped < > and &, so nothing in `value` can
+ * close the tag either.
+ */
+export function jsonLdScriptTag(value: unknown) {
+  return `<script type="application/ld+json">${serializeJsonLd(value)}</` + `script>`;
+}
+
+/**
+ * Describes the app itself, sourced from the active game's own metadata so the sky and
+ * genshin builds each declare their own identity rather than a shared one.
+ */
+export function softwareApplicationLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: game.meta.title,
+    description: game.meta.description,
+    url: CANONICAL_ORIGIN,
+    applicationCategory: 'MultimediaApplication',
+    operatingSystem: 'Any (web browser)',
+    offers: { '@type': 'Offer', price: 0, priceCurrency: 'USD' },
+    featureList: [
+      `Compose songs for ${game.display.name}`,
+      'Practice a song with approaching circles or guided mode',
+      'Import and convert MIDI files',
+      'Record and export your own sheets',
+      'Connect a MIDI device',
+    ],
+    author: {
+      '@type': 'Person',
+      name: 'Specy',
+      url: 'https://specy.app',
+      sameAs: ['https://github.com/Specy'],
+    },
+    sameAs: ['https://github.com/Specy/genshin-music'],
+  };
+}

--- a/src/routes/backup/+page.svelte
+++ b/src/routes/backup/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import AppButton from '$cmp/inputs/AppButton.svelte';
   import AppLink from '$cmp/AppLink.svelte';
   import Row from '$cmp/layout/Row.svelte';
@@ -264,6 +265,7 @@
     text={t('home:backup_name')}
     description="Manage the backups in the app, download or import songs, themes, or all of them"
   />
+  <PageHeading text={t('home:backup_name')} />
   <div class="backup-page">
     <Column gap="1rem" style="padding-bottom:1rem">
       <Card background="none" border="secondary" gap="0.8rem">

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -139,7 +139,7 @@
     <PromotionCard alwaysVisible />
     <Column gap="1rem">
       <Row justify="between" align="center" gap="1rem" style="flex-wrap:wrap">
-        <Header>Posts</Header>
+        <Header type="h2" textSize="2rem">Posts</Header>
         <Row align="center" gap="0.5rem">
           <ComboBox
             items={selectedTags}
@@ -169,7 +169,7 @@
     <!-- The partners have no page of their own any more; this is where they live. Last on the
          index because the posts are what the page is for. -->
     <Column gap="1rem">
-      <Header>{t('home:partners_name')}</Header>
+      <Header type="h2" textSize="2rem">{t('home:partners_name')}</Header>
       <Partners />
     </Column>
   </Column>

--- a/src/routes/blog/posts/connect-midi-device/+page.svelte
+++ b/src/routes/blog/posts/connect-midi-device/+page.svelte
@@ -12,7 +12,7 @@
       Since vesion V2.3 there has been the possibility to connect a MIDI keyboard to the app. This
       functionality is available everywhere except on Safari browsers.
     </p>
-    <Header margin="1rem 0">How to connect the MIDI device</Header>
+    <Header type="h2" textSize="2rem" margin="1rem 0">How to connect the MIDI device</Header>
     <p class="blog-p">
       To connect the MIDI keyboard to the app, get the appropriate cable to connect it to your
       device. If you are on android you might have to select the "midi" option in the USB connection
@@ -25,7 +25,7 @@
       app's keys. A default preset is provided, in case it does not match your keyboard, you can create
       a new preset and assign the keys as you wish.
     </p>
-    <Header margin="1rem 0">Create a new MIDI preset</Header>
+    <Header type="h2" textSize="2rem" margin="1rem 0">Create a new MIDI preset</Header>
     <p class="blog-p">
       To create a new midi preset click the "create new preset" button, you will be asked how to
       name it, once written, a new empty preset will be created. You now have to press the button of
@@ -37,7 +37,7 @@
       follow the same technique as the notes, click the button of the shortcut you want to map, and
       then press the corresponding key on your keyboard.
     </p>
-    <Header margin="1rem 0">Use your phone/pc as a MIDI keyboard</Header>
+    <Header type="h2" textSize="2rem" margin="1rem 0">Use your phone/pc as a MIDI keyboard</Header>
     <p class="blog-p">
       Using the app, you can turn your phone or pc into a MIDI keyboard, using the <AppLink
         href="/zen-keyboard">Zen Keyboard</AppLink

--- a/src/routes/blog/posts/easyplay-1s/+page.svelte
+++ b/src/routes/blog/posts/easyplay-1s/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <BaseBlogPost metadata={easyplay1sMetadata}>
-  <Header>What it is</Header>
+  <Header type="h2" textSize="2rem">What it is</Header>
 
   <p class="blog-p">
     The EASYPLAY 1s is a keyboard that uses the same layout as Sky Music Nightly, and you can use it
@@ -24,7 +24,7 @@
   <AppLink href="https://summertones-1.kckb.me/18287a61" class="blog-link">
     <BlogImage src="{base}/assets/blog/easyplay.webp" alt="Easyplay 1S" height="15rem" />
   </AppLink>
-  <Header>The features</Header>
+  <Header type="h2" textSize="2rem">The features</Header>
   <p class="blog-p">
     It is a MIDI keyboard which uses the same layout as Sky Music Nightly, the main features are:
   </p>
@@ -38,7 +38,7 @@
     It's made out of translucent black plastic with replaceable keycaps and rubber pads to prevent
     slipping.
   </p>
-  <Header>Demo video</Header>
+  <Header type="h2" textSize="2rem">Demo video</Header>
   <!-- old's own BlogIframe never had a title prop at all (BlogUl.tsx / this post's sole call
          site) - a pre-existing accessibility gap, preserved rather than fabricating a title old
          never had. -->

--- a/src/routes/blog/posts/how-to-create-a-beatmap/+page.svelte
+++ b/src/routes/blog/posts/how-to-create-a-beatmap/+page.svelte
@@ -19,7 +19,7 @@
     song, you can send it to someone else and they can play it too.
   </p>
 
-  <Header margin="1rem 0">The player</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">The player</Header>
   <p class="blog-p">
     This is where a beatmap gets played. The lanes are in the middle, the keys you press are the
     circles in the two bottom corners, and the long bars are notes you have to keep held instead of
@@ -28,7 +28,7 @@
   </p>
   <BlogImage src="{base}/assets/blog/help-vsrg-beatmap.webp" alt="The VSRG player" />
 
-  <Header margin="1rem 0">The composer</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">The composer</Header>
   <p class="blog-p">
     This is where a beatmap is made. Every row is one of the lanes, time goes from left to right,
     and you click on the grid to put a note where you want it. The circles are notes you tap once,
@@ -38,7 +38,7 @@
   </p>
   <BlogImage src="{base}/assets/blog/help-vsrg-beatmap-2.webp" alt="The VSRG composer" />
 
-  <Header margin="1rem 0">Choosing the song</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Choosing the song</Header>
   <p class="blog-p">
     A beatmap is always made for a song you already have in the app, so the first thing to do is
     open the settings menu of the VSRG composer and pick one under "Background Song". From then on
@@ -47,7 +47,7 @@
     it, that part is explained in the other post.
   </p>
 
-  <Header margin="1rem 0">Letting the app make the first version</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Letting the app make the first version</Header>
   <p class="blog-p">
     In that same menu there is a "Generate beatmap" button, greyed out until a song is picked. It
     makes a whole beatmap in one go, you say how hard you want it and which part of the song you
@@ -90,7 +90,7 @@
     own, none of them just disappear.
   </p>
 
-  <Header margin="1rem 0">Reading the result</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Reading the result</Header>
   <p class="blog-p">
     When it's finished, a "Result" box appears at the bottom of the window and the new beatmap is
     already open behind it, so you can close the window and listen to it straight away.
@@ -128,7 +128,7 @@
     generating again later will leave it alone.
   </p>
 
-  <Header margin="1rem 0">Placing the notes yourself</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Placing the notes yourself</Header>
   <p class="blog-p">
     You can also make the whole thing by hand, and even a generated beatmap usually wants a bit of
     fixing. The selector at the bottom left is where you choose what a click does, "Tap" adds a note
@@ -151,7 +151,7 @@
     the bottom right.
   </p>
 
-  <Header margin="1rem 0">Playing it</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Playing it</Header>
   <p class="blog-p">
     Once you're happy with it, go to the <AppLink href="/vsrg-player">VSRG player</AppLink>, open
     the song menu and pick your beatmap. You can press the keys on screen or on a keyboard, and if

--- a/src/routes/blog/posts/how-to-use-composer/+page.svelte
+++ b/src/routes/blog/posts/how-to-use-composer/+page.svelte
@@ -61,7 +61,7 @@
       BPM of your song
     </li>
   </ol>
-  <Header>Composer Tools</Header>
+  <Header type="h2" textSize="2rem">Composer Tools</Header>
   <!-- QUIRK: /blog/midi-conversion and /blog/ai-conversion below are broken links - the real
          routes are /blog/posts/midi-transpose and /blog/posts/video-audio-transpose. Preserved
          from old, not fixed. -->
@@ -222,7 +222,7 @@
     <li>This will move the layer one position up or down, just used to organise layers.</li>
   </ol>
   {#if !globalConfigStore.state.IS_MOBILE}
-    <Header margin="1rem 0">Composer shortcuts</Header>
+    <Header type="h2" textSize="2rem" margin="1rem 0">Composer shortcuts</Header>
     <p class="blog-p">
       The composer has some shortcuts you can use, if you want to change them, go to the <AppLink
         href="/keybinds">keybinds page</AppLink

--- a/src/routes/blog/posts/how-to-use-player/+page.svelte
+++ b/src/routes/blog/posts/how-to-use-player/+page.svelte
@@ -32,7 +32,7 @@
              preserved bug as how-to-use-composer.tsx's equivalent link. -->
   </p>
 
-  <Header margin="1rem 0">How to use the player</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">How to use the player</Header>
   {#if APP_NAME !== 'Genshin'}
     <p class="blog-p">
       The images below are from the genshin version of the app, but the functionality is the same
@@ -108,7 +108,7 @@
       which is not this one.
     </li>
   </ol>
-  <Header margin="1rem 0">Player settings</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Player settings</Header>
   <BlogImage src="{base}/assets/blog/help-player-3.webp" alt="Player settings" />
   <ol class="blog-ol">
     <li>
@@ -159,7 +159,7 @@
     </li>
   </ol>
   {#if !globalConfigStore.state.IS_MOBILE}
-    <Header>Player shortcuts</Header>
+    <Header type="h2" textSize="2rem">Player shortcuts</Header>
     <p class="blog-p">
       The player has some shortcuts you can use, if you want to change them, go to the <AppLink
         href="/keybinds">keybinds page</AppLink

--- a/src/routes/blog/posts/how-to-use-vsrg-composer/+page.svelte
+++ b/src/routes/blog/posts/how-to-use-vsrg-composer/+page.svelte
@@ -22,7 +22,7 @@
     the <AppLink href="/vsrg-player">VSRG player</AppLink>. You will have to press the notes in time
     to earn more points.
   </p>
-  <Header margin="1rem 0">How to setup a beatmap</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">How to setup a beatmap</Header>
   <p class="blog-p">
     When creating a beatmap, you first have to choose which song the beatmap is for, and set some
     settings related to it. Let's start off exploring all the settings in the VSRG composer!
@@ -85,7 +85,7 @@
     <li>Mutes the layer</li>
   </ol>
 
-  <Header margin="1rem 0">How to use the composer</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">How to use the composer</Header>
   <p class="blog-p">
     Once finished setting up the song and settings, you can start actually composing the beatmap. To
     do actions on the canvas you can click the boxes, you have 3 actions you can do, add a "tap" hit
@@ -141,7 +141,7 @@
     </li>
   </ol>
   {#if !globalConfigStore.state.IS_MOBILE}
-    <Header margin="1rem 0">VSRG Composer shortcuts</Header>
+    <Header type="h2" textSize="2rem" margin="1rem 0">VSRG Composer shortcuts</Header>
 
     <p class="blog-p">
       The VSRG composer has some shortcuts you can use, if you want to change them, go to the <AppLink

--- a/src/routes/blog/posts/midi-transpose/+page.svelte
+++ b/src/routes/blog/posts/midi-transpose/+page.svelte
@@ -13,7 +13,7 @@
     file for the song and use the MIDI transposing tools to convert it into a music sheet.
   </p>
 
-  <Header margin="1rem 0">Open a MIDI file</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Open a MIDI file</Header>
   <p class="blog-p">
     Once you found your MIDI file, visit the <AppLink href="/composer">composer</AppLink> and open the
     song menu.
@@ -26,7 +26,7 @@
     Audio transpose guide
   </AppLink>.
   <BlogImage src="{base}/assets/blog/midi-btn.webp" alt="MIDI button" />
-  <Header margin="1rem 0">Transpose a MIDI file</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Transpose a MIDI file</Header>
   <p class="blog-p">
     After having selected the file, you can start changing the import settings to best convert the
     song to the app sheet. The MIDI song doesn't perfectly match the music sheet of the app, so you

--- a/src/routes/blog/posts/video-audio-transpose/+page.svelte
+++ b/src/routes/blog/posts/video-audio-transpose/+page.svelte
@@ -16,20 +16,20 @@
       Spotify's Basic Pitch
     </AppLink>.
   </p>
-  <Header margin="1rem 0">Warnings</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Warnings</Header>
   <p class="blog-p">
     This feature is to be used only as a last resort after you cannot find a MIDI song to transpose,
     or you can't do it by hand. It is not meant to create a perfect transposition, as the conversion
     is very difficult, but mostly as a starting point to help you transpose a song manually.
   </p>
 
-  <Header margin="1rem 0">Best practices</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">Best practices</Header>
   <p class="blog-p">
     It is best if you can find a video/audio of a song that uses a single instrument, the piano is
     the easiest to convert. Even better if there is no background noise.
   </p>
 
-  <Header margin="1rem 0">How to</Header>
+  <Header type="h2" textSize="2rem" margin="1rem 0">How to</Header>
   <p class="blog-p">
     The transposition steps are very similar to the ones of MIDI transposition, if you want to see
     how to do that, visit the <AppLink href="/blog/posts/midi-transpose">

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -3,6 +3,7 @@
   import { base } from '$app/paths';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import SimpleMenu from '$cmp/shell/SimpleMenu.svelte';
   import MenuButton from '$cmp/menu/MenuButton.svelte';
   import AppButton from '$cmp/inputs/AppButton.svelte';
@@ -72,8 +73,9 @@
 <DefaultPage excludeMenu={true} menu={changelogMenu}>
   <PageMetadata
     text={`${t('home:changelog_name')} V${APP_VERSION}`}
-    description={`Changelog V${APP_VERSION}\n${CHANGELOG[0]?.changes.join(';')}`}
+    description={`Changelog V${APP_VERSION}. ${CHANGELOG[0]?.changes.join('; ')}`}
   />
+  <PageHeading text={`${t('home:changelog_name')} V${APP_VERSION}`} />
   <div class="changelog-page">
     <div class="changelog-page-title">
       {t('home:changelog_name')}

--- a/src/routes/composer/+page.svelte
+++ b/src/routes/composer/+page.svelte
@@ -4,6 +4,8 @@
   import AppBackground from '$cmp/theme/AppBackground.svelte';
   import Composer from '$cmp/pages/Composer/Composer.svelte';
   import { setPageVisited } from '$stores/PageVisitStore.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
+  import { t } from '$i18n/binding.svelte';
 
   // QUIRK (load-bearing - read before "fixing" this): page.url.searchParams ($app/state) throws
   // during svelte-kit's prerender crawl on a page with prerendering enabled (this whole app
@@ -27,5 +29,6 @@
 </script>
 
 <AppBackground page="Composer">
+  <PageHeading text={t('home:composer_name')} />
   <Composer {songId} {showMidi} />
 </AppBackground>

--- a/src/routes/error/+page.svelte
+++ b/src/routes/error/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import AppButton from '$cmp/inputs/AppButton.svelte';
   import SongMenu from '$cmp/SongMenu.svelte';
   import ErrorSongRow from '$cmp/pages/ErrorSongRow.svelte';
@@ -67,6 +68,7 @@
     text={t('common:error')}
     description="View the errors that happened in the app to send bug reports and to try to recover your songs"
   />
+  <PageHeading text={t('common:error')} />
   <div style="text-align:center">
     {t('error:error_page_description')}
     <a href="https://discord.gg/Arsf65YYHq" target="_blank" rel="noreferrer" class="discord-link">

--- a/src/routes/keybinds/+page.svelte
+++ b/src/routes/keybinds/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import BaseNote from '$cmp/BaseNote.svelte';
   import { KeyboardProvider } from '$lib/providers/KeyboardProvider';
   import type { KeyboardCode } from '$lib/providers/KeyboardProvider/KeyboardTypes';
@@ -94,6 +95,7 @@
     text={t('home:keybinds_or_midi_name')}
     description="Change the app keyboard keybinds and MIDI input keys"
   />
+  <PageHeading text={t('home:keybinds_or_midi_name')} />
   <Column gap="1rem" style="padding-bottom:1rem">
     <Card background="none" border="secondary" gap="0.8rem">
       <Header type="h2">

--- a/src/routes/player/+page.svelte
+++ b/src/routes/player/+page.svelte
@@ -3,6 +3,8 @@
   import AppBackground from '$cmp/theme/AppBackground.svelte';
   import Player from '$cmp/pages/Player/Player.svelte';
   import { setPageVisited } from '$stores/PageVisitStore.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
+  import { t } from '$i18n/binding.svelte';
 
   // AppBackground is wired at the route level (not inside Player.svelte itself) - page-visit
   // tracking lives here too; Player.svelte owns its own reactive t() binding internally.
@@ -12,5 +14,6 @@
 </script>
 
 <AppBackground page="Main">
+  <PageHeading text={t('home:player_name')} />
   <Player />
 </AppBackground>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import { setPageVisited } from '$stores/PageVisitStore.svelte';
 
   // QUIRK: this whole page is hardcoded English, no t() calls anywhere - preserved as-is, not
@@ -13,6 +14,7 @@
 
 <DefaultPage>
   <PageMetadata text="Privacy" description="Privacy policy for the app" />
+  <PageHeading text="Privacy" />
   <span class="privacy-text">
     This website uses cookies to collect data about usage of the app through IP anonymized Google
     Analytics. We use this information to improve user experience and find how our users use the

--- a/src/routes/sheet-visualizer/+page.svelte
+++ b/src/routes/sheet-visualizer/+page.svelte
@@ -131,9 +131,9 @@
     <h1 class="onprint" style="color:black">
       {game.i18n.interpolation.APP_NAME} Music Nightly
     </h1>
-    <h1 class="onprint" style="color:black">
+    <h2 class="onprint" style="color:black">
       {currentSong ? currentSong?.name : ''}
-    </h1>
+    </h2>
     <div style="width:100%" class="noprint">
       <div class="sheet-header">
         <h2 class="sheet-title text-ellipsis" style="margin-top:0.8rem">

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,62 @@
+import { CANONICAL_ORIGIN } from '$lib/seo';
+import { IS_BETA } from '$lib/env';
+
+export const prerender = true;
+
+/**
+ * Routes that exist but are not content: surfaces that only make sense with the reader's
+ * own data behind them, and the error/maintenance pages.
+ */
+const EXCLUDED = new Set([
+  // a build-time meta-refresh stub for old deep links (routes/partners/+page.ts), not a page
+  '/partners',
+  '/error',
+  '/delete-cache',
+  '/backup',
+  '/transfer',
+  '/theme',
+  '/keybinds',
+]);
+
+/** Discovered from the route files, so a new page is listed the moment it exists. */
+function routes() {
+  const modules = import.meta.glob('/src/routes/**/+page.svelte');
+  return Object.keys(modules)
+    .map((file) => file.replace('/src/routes', '').replace('/+page.svelte', '') || '/')
+    .filter((route) => !route.includes('['))
+    .filter((route) => !EXCLUDED.has(route))
+    .sort();
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export const GET = async () => {
+  // The beta is noindex (RootMetadata), so listing its urls would only ever contradict
+  // that. It still builds a sitemap, and that sitemap is empty on purpose.
+  const paths = IS_BETA ? [] : routes();
+  const buildDate = new Date().toISOString().slice(0, 10);
+
+  // Deliberately CANONICAL_ORIGIN and not the deployed origin: the subpath builds serve
+  // the same pages under /skyMusic and /genshinMusic, and both should point a crawler at
+  // the one origin those pages canonicalise to.
+  const entries = paths.map(
+    (route) => `  <url>
+    <loc>${escapeXml(CANONICAL_ORIGIN + route)}</loc>
+    <lastmod>${buildDate}</lastmod>
+  </url>`
+  );
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries.join('\n')}
+</urlset>`;
+
+  return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
+};

--- a/src/routes/theme/+page.svelte
+++ b/src/routes/theme/+page.svelte
@@ -3,6 +3,7 @@
   import cloneDeep from 'lodash.clonedeep';
   import DefaultPage from '$cmp/shell/DefaultPage.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import AppButton from '$cmp/inputs/AppButton.svelte';
   import FilePicker, { type FileElement } from '$cmp/inputs/FilePicker.svelte';
   import Column from '$cmp/layout/Column.svelte';
@@ -117,6 +118,7 @@
     text={t('home:themes_name')}
     description="Change the theme of the app, set all colors and backgrounds, make elements translucent and share/import themes"
   />
+  <PageHeading text={t('home:themes_name')} />
   <Column gap="1rem" style="padding-bottom:1rem">
     <div>
       <Header type="h2">

--- a/src/routes/vsrg-composer/+page.svelte
+++ b/src/routes/vsrg-composer/+page.svelte
@@ -9,6 +9,7 @@
   import { DEFAULT_VSRG_KEYS_MAP } from '$core/legacyConfig';
   import { t } from '$i18n/binding.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import DecoratedCard from '$cmp/layout/DecoratedCard.svelte';
   import VsrgComposerMenu from '$cmp/pages/VsrgComposer/VsrgComposerMenu.svelte';
   import VsrgTop from '$cmp/pages/VsrgComposer/VsrgTop.svelte';
@@ -915,6 +916,7 @@
     text={`${t('home:vsrg_composer_name')} - ${vsrg.name ?? 'Unnamed'}`}
     description="Create new VSRG songs using existing background songs and create your own beatmap for it."
   />
+  <PageHeading text={`${t('home:vsrg_composer_name')} - ${vsrg.name ?? 'Unnamed'}`} />
   <VsrgComposerMenu
     data={{
       settings,

--- a/src/routes/vsrg-player/+page.svelte
+++ b/src/routes/vsrg-player/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import AppBackground from '$cmp/theme/AppBackground.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import VsrgPlayerMenu from '$cmp/pages/VsrgPlayer/VsrgPlayerMenu.svelte';
   import VsrgPlayerCanvas from '$cmp/pages/VsrgPlayer/VsrgPlayerCanvas.svelte';
   import VsrgPlayerKeyboard from '$cmp/pages/VsrgPlayer/VsrgPlayerKeyboard.svelte';
@@ -175,6 +176,7 @@
 
 <AppBackground page="Main">
   <PageMetadata text={t('home:vsrg_player_name')} description="Play or practice VSRG songs" />
+  <PageHeading text={t('home:vsrg_player_name')} />
   <VsrgPlayerMenu {settings} onSettingsUpdate={handleSettingChange} {onSongSelect} />
   <div class="vsrg-player-page appear-on-mount">
     <div class="vsrg-player-grid">

--- a/src/routes/zen-keyboard/+page.svelte
+++ b/src/routes/zen-keyboard/+page.svelte
@@ -7,6 +7,7 @@
   import ZenKeypad from '$cmp/pages/ZenKeyboard/ZenKeypad.svelte';
   import ZenKeyboardMenu from '$cmp/pages/ZenKeyboard/ZenKeyboardMenu.svelte';
   import PageMetadata from '$cmp/shell/PageMetadata.svelte';
+  import PageHeading from '$cmp/shell/PageHeading.svelte';
   import { ZenKeyboardSettings, type ZenKeyboardSettingsDataType } from '$core/BaseSettings';
   import { Instrument, type ObservableNote } from '$lib/audio/Instrument.svelte';
   import { metronome } from '$lib/audio/Metronome';
@@ -198,6 +199,7 @@
     text={t('home:zen_keyboard_name')}
     description="The simplest keyboard in the app, focus only on playing manually with all the features of the player, instrument and pitch selection, animations and metronome"
   />
+  <PageHeading text={t('home:zen_keyboard_name')} />
   <ZenKeyboardMenu
     {settings}
     {isMetronomePlaying}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -110,6 +110,14 @@ const config = {
       // same allowlist mechanism as the dead blog links above. Compared bare (never
       // base-prefixed): the bug IS the missing prefix, so it only ever surfaces as this
       // exact unprefixed path regardless of which base the build uses.
+      // Neither file is linked from anywhere in the app, so the crawler never reaches
+      // them on its own. Base-prefixed for the same reason the dead-link allowlist below
+      // is: on the *-no-root builds every prerendered path carries the subpath.
+      // Nothing links to the sitemap, so the crawler never reaches it on its own. Written
+      // base-RELATIVE, unlike the handleHttpError allowlist below: Kit prepends the
+      // configured base to each entry itself, and a base-prefixed one here builds
+      // /skyMusic/skyMusic/sitemap.xml and fails the *-no-root builds.
+      entries: ['*', '/sitemap.xml'],
       handleHttpError: ({ path, referrer, message }) => {
         const knownDeadLinks = [
           '/blog/midi-conversion',

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 import {readFileSync, readdirSync} from 'node:fs'
-import {join} from 'node:path'
+import {join, sep} from 'node:path'
 import {i18n, isLanguageLoaded, setI18nLanguage} from '../src/lib/i18n/i18n'
 
 describe('i18n core', () => {
@@ -40,17 +40,43 @@ describe('interpolation hands values through unescaped, and Svelte is what escap
      * risk is a `{@html}` added later over a `t(...)` - which is exactly the edit this catches and
      * a per-surface test would not.
      */
+    /**
+     * ALLOWLISTED, and the bar for adding to this list is high: the value must be machine
+     * generated and escaped at the point of interpolation, never a translated or
+     * user-supplied string.
+     *
+     * HomePage.svelte emits the page's schema.org JSON-LD, which has to be a real <script>
+     * element - <svelte:element this="script"> renders nothing in Svelte, and a literal
+     * <script> in a component is taken as its instance script, so {@html} is the only way.
+     * Its payload comes from game.json via seo.ts's serializeJsonLd, which escapes < > and
+     * & so nothing interpolated can close the tag.
+     */
+    const HTML_ALLOWED = new Set(['src/lib/components/shell/HomePage.svelte'])
+
     it('no component renders anything with {@html}', () => {
         const offenders: string[] = []
         const walk = (dir: string) => {
             for (const entry of readdirSync(dir, {withFileTypes: true})) {
                 const path = join(dir, entry.name)
                 if (entry.isDirectory()) walk(path)
-                else if (entry.name.endsWith('.svelte') && readFileSync(path, 'utf8').includes('{@html'))
+                else if (
+                    entry.name.endsWith('.svelte') &&
+                    readFileSync(path, 'utf8').includes('{@html') &&
+                    !HTML_ALLOWED.has(path.split(sep).join('/'))
+                )
                     offenders.push(path)
             }
         }
         walk('src')
         expect(offenders).toEqual([])
+    })
+
+    it('no allowlisted {@html} interpolates a translated string', () => {
+        for (const path of HTML_ALLOWED) {
+            const source = readFileSync(path, 'utf8')
+            for (const [, expression] of source.matchAll(/\{@html ([\s\S]*?)\}\n/g)) {
+                expect(expression, `${path} interpolates t() into {@html}`).not.toMatch(/\bt\(/)
+            }
+        }
     })
 })


### PR DESCRIPTION
## Why

The same pages are served from the per-game domain, the `/skyMusic` and `/genshinMusic` subpath builds and the beta, and **none of them declared which URL they wanted to be ranked as** — so the copies compete instead of consolidating. The new home page also had no headings at all.

Context: `specy.github.io/skyMusic/` is still live and currently outranks `sky-music.specy.app` for the brand query "sky music nightly". Declaring a canonical is the half of that we control.

## Canonical

- Each game's `game.json` gains `meta.canonicalOrigin`; `RootMetadata` emits a canonical and `og:url` from it on every page.
- `appPathname` drops the base — exactly the part that differs between builds — so **the subpath builds point back at the bare origin**, which is what makes the `/skyMusic` copies consolidate rather than compete.
- `PUBLIC_CANONICAL_ORIGIN` overrides it: **one env var when the single-domain deploy lands**, not a code change.
- It lives in `RootMetadata` and not `PageMetadata` because some routes mount several `PageMetadata` on purpose (see `routes/theme/+page.svelte`'s header) and Svelte dedupes `<title>` but not `<link>`.

## Sitemap and robots

- New `/sitemap.xml`, listing canonical-origin URLs whichever variant built it, and **empty on the beta**, which is `noindex`.
- Per-game `robots.txt` point at it with the absolute URL the directive requires (they are the per-game static overlay, so each gets its own origin).
- The beta deliberately does **not** `Disallow:` — blocking the crawl would stop anything ever reading its `noindex` tag, which is the standard way to get a beta indexed by accident.

## Headings

The home page had none. The app name becomes the `h1` and the section cards `h2`. Blog post sections, settings group titles and the course sidebar all defaulted to `Header`'s `h1`, so pages carried up to eight; **demoted ones keep their current size explicitly**, since `Header` derives `font-size` from the level — verified no pre-existing `h2` changed.

App surfaces with no room for a visible heading get a hidden one via `PageHeading` — placed **on the route, not inside `Player` and `Composer`**, which the theme page also embeds for its live preview.

Also: `changelog`'s description interpolated a literal `\n` into the meta tag.

## Worth your review

`test/i18n.test.ts` bans `{@html}` repo-wide to keep translated strings out of markup. JSON-LD has to be a real `<script>` and `{@html}` is the only way to emit one — `<svelte:element this="script">` renders nothing in Svelte, and a literal script tag is taken as the component's instance script.

So **that single call site is allowlisted**, with a second test asserting no allowlisted `{@html}` interpolates `t()` — the actual risk the original guard describes. This loosens a security invariant, narrowly and with a compensating test, but it is the one change here that deserves a decision rather than a skim.

## Verification

- `npm test` — **2379 passed**, 33 skipped
- `npm run check` and `check:sky` — **0 errors, 0 warnings**
- `npm run lint`, `prettier --check` — clean
- `build:sky`, `build:genshin`, `build:all`, `build:all-no-root`, and a beta build — all succeed
- Check over the build output (one non-empty `<title>`, one canonical, one `h1`, valid JSON-LD, every sitemap URL resolves to a built page): **26/26 pages pass for each game**
- Subpath build spot-checked: `build/skyMusic/composer.html` canonicalises to `https://sky-music.specy.app/composer`, with no `/skyMusic` segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)